### PR TITLE
bugfix: Fix missing ids in NoSubscriptionsFound criteria output

### DIFF
--- a/src/Subscription/SubscriptionIds.php
+++ b/src/Subscription/SubscriptionIds.php
@@ -11,7 +11,7 @@ use JsonSerializable;
 /**
  * @implements \IteratorAggregate<SubscriptionId>
  */
-final readonly class SubscriptionIds implements IteratorAggregate, Countable
+final readonly class SubscriptionIds implements IteratorAggregate, Countable, JsonSerializable
 {
     /**
      * @param array<string, SubscriptionId> $subscriptionIdsById
@@ -68,5 +68,13 @@ final readonly class SubscriptionIds implements IteratorAggregate, Countable
     public function toStringArray(): array
     {
         return array_values(array_map(static fn (SubscriptionId $id) => $id->value, $this->subscriptionIdsById));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toStringArray();
     }
 }

--- a/tests/PHPUnit/Engine/SubscriptionEngineTest.php
+++ b/tests/PHPUnit/Engine/SubscriptionEngineTest.php
@@ -352,7 +352,7 @@ final class SubscriptionEngineTest extends TestCase
         );
         $this->assertEmittedEngineEvents(
             'ResetStarted: Start to setup',
-            'NoSubscriptionsFound: No subscriptions found for criteria: {"ids":{},"status":["NEW","BOOTING","ACTIVE","DETACHED","ERROR"]}'
+            'NoSubscriptionsFound: No subscriptions found for criteria: {"ids":["s3"],"status":["NEW","BOOTING","ACTIVE","DETACHED","ERROR"]}'
         );
         self::assertTrue($result->successful());
         self::assertFalse($this->subscriptionStore->_hasPendingChanges(), 'Subscription store has pending changes');


### PR DESCRIPTION
Not sure if this was intented like this for now / to be addressed later since it was covered by a test as is, but I just stumpled upon it.