### PR TITLE
FEATURE: Add `getSubscriptions` and `getSubscription` to Subscription Engine

### DIFF
--- a/src/Store/SubscriptionStore.php
+++ b/src/Store/SubscriptionStore.php
@@ -15,6 +15,8 @@ interface SubscriptionStore
 {
     public function setup(): void;
 
+    public function findByCriteria(SubscriptionCriteria $criteria): Subscriptions;
+
     public function findByCriteriaForUpdate(SubscriptionCriteria $criteria): Subscriptions;
 
     public function add(Subscription $subscription): void;

--- a/src/SubscriptionEngine.php
+++ b/src/SubscriptionEngine.php
@@ -39,7 +39,9 @@ use Wwwision\SubscriptionEngine\Subscription\Position;
 use Wwwision\SubscriptionEngine\Subscription\RunMode;
 use Wwwision\SubscriptionEngine\Subscription\Subscription;
 use Wwwision\SubscriptionEngine\Subscription\SubscriptionError;
+use Wwwision\SubscriptionEngine\Subscription\SubscriptionId;
 use Wwwision\SubscriptionEngine\Subscription\SubscriptionIds;
+use Wwwision\SubscriptionEngine\Subscription\Subscriptions;
 use Wwwision\SubscriptionEngine\Subscription\SubscriptionStatus;
 use Wwwision\SubscriptionEngine\Subscription\SubscriptionStatusFilter;
 
@@ -133,6 +135,22 @@ final class SubscriptionEngine
             }
         }
         return $errors === [] ? Result::success() : Result::failed(Errors::fromArray($errors));
+    }
+
+    public function getSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Subscriptions
+    {
+        $subscriptionCriteria = SubscriptionCriteria::forEngineCriteriaAndStatus($criteria ??= SubscriptionEngineCriteria::noConstraints(), SubscriptionStatusFilter::any());
+        return $this->subscriptionStore->findByCriteria($subscriptionCriteria);
+    }
+
+    public function getSubscription(SubscriptionId $subscriptionId): Subscription|null
+    {
+        $subscriptionCriteria = SubscriptionCriteria::forEngineCriteriaAndStatus(SubscriptionEngineCriteria::create([$subscriptionId]), SubscriptionStatusFilter::any());
+        $subscriptions = $this->subscriptionStore->findByCriteria($subscriptionCriteria);
+        if (!$subscriptions->contain($subscriptionId)) {
+            return null;
+        }
+        return $subscriptions->get($subscriptionId);
     }
 
     // ------------------------------

--- a/tests/Mocks/InMemorySubscriptionStore.php
+++ b/tests/Mocks/InMemorySubscriptionStore.php
@@ -28,7 +28,17 @@ final class InMemorySubscriptionStore implements SubscriptionStore
         $this->setupCalled = true;
     }
 
+    public function findByCriteria(SubscriptionCriteria $criteria): Subscriptions
+    {
+        return $this->filterByCriteria($criteria);
+    }
+
     public function findByCriteriaForUpdate(SubscriptionCriteria $criteria): Subscriptions
+    {
+        return $this->filterByCriteria($criteria);
+    }
+
+    private function filterByCriteria(SubscriptionCriteria $criteria): Subscriptions
     {
         $filteredSubscriptions = array_filter($this->subscriptionsById, static function (Subscription $subscription) use ($criteria) {
             if ($criteria->ids !== null && !in_array($subscription->id->value, $criteria->ids->toStringArray(), true)) {

--- a/tests/PHPUnit/Engine/SubscriptionEngineTest.php
+++ b/tests/PHPUnit/Engine/SubscriptionEngineTest.php
@@ -541,6 +541,89 @@ final class SubscriptionEngineTest extends TestCase
         self::assertTrue($result->successful());
     }
 
+    public function test_getSubscriptions_returns_empty_set_if_no_subscriptions_exist(): void
+    {
+        $subscriptions = $this->subscriptionEngine()->getSubscriptions();
+        self::assertTrue($subscriptions->isEmpty());
+    }
+
+    public function test_getSubscriptions_returns_all_subscriptions_without_criteria(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ACTIVE),
+            Subscription::create(id: 's2', runMode: RunMode::FROM_BEGINNING, status: SubscriptionStatus::BOOTING),
+            Subscription::create(id: 's3', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::DETACHED),
+        );
+
+        $subscriptions = $this->subscriptionEngine()->getSubscriptions();
+
+        self::assertSame(['s1', 's2', 's3'], $subscriptions->getIds()->toStringArray());
+    }
+
+    public function test_getSubscriptions_filters_by_criteria(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ACTIVE),
+            Subscription::create(id: 's2', runMode: RunMode::FROM_BEGINNING, status: SubscriptionStatus::BOOTING),
+            Subscription::create(id: 's3', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::DETACHED),
+        );
+
+        $subscriptions = $this->subscriptionEngine()->getSubscriptions(SubscriptionEngineCriteria::create(ids: ['s1', 's3']));
+
+        self::assertSame(['s1', 's3'], $subscriptions->getIds()->toStringArray());
+    }
+
+    public function test_getSubscriptions_returns_subscriptions_of_any_status(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::NEW),
+            Subscription::create(id: 's2', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::BOOTING),
+            Subscription::create(id: 's3', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ACTIVE),
+            Subscription::create(id: 's4', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::DETACHED),
+            Subscription::create(id: 's5', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ERROR),
+        );
+
+        $subscriptions = $this->subscriptionEngine()->getSubscriptions();
+
+        self::assertSame(['s1', 's2', 's3', 's4', 's5'], $subscriptions->getIds()->toStringArray());
+    }
+
+    public function test_getSubscription_returns_null_if_no_subscription_with_given_id_exists(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ACTIVE),
+        );
+
+        self::assertNull($this->subscriptionEngine()->getSubscription(SubscriptionId::fromString('non-existing')));
+    }
+
+    public function test_getSubscription_returns_matching_subscription(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::ACTIVE),
+            Subscription::create(id: 's2', runMode: RunMode::FROM_BEGINNING, status: SubscriptionStatus::BOOTING)->with(position: Position::fromInteger(7)),
+        );
+
+        $subscription = $this->subscriptionEngine()->getSubscription(SubscriptionId::fromString('s2'));
+
+        self::assertNotNull($subscription);
+        self::assertSame('s2', $subscription->id->value);
+        self::assertSame(SubscriptionStatus::BOOTING, $subscription->status);
+        self::assertSame(7, $subscription->position->value);
+    }
+
+    public function test_getSubscription_returns_subscription_in_any_status(): void
+    {
+        $this->subscriptionStore->_setSubscriptions(
+            Subscription::create(id: 's1', runMode: RunMode::FROM_NOW, status: SubscriptionStatus::DETACHED),
+        );
+
+        $subscription = $this->subscriptionEngine()->getSubscription(SubscriptionId::fromString('s1'));
+
+        self::assertNotNull($subscription);
+        self::assertSame(SubscriptionStatus::DETACHED, $subscription->status);
+    }
+
     public function test_reset_handles_errors_in_reset_function(): void
     {
         $this->subscriptionStore->_setSubscriptions(


### PR DESCRIPTION
Exposes read access to the subscription store via two new methods on `SubscriptionEngine`: `getSubscriptions(SubscriptionEngineCriteria|null)` returning all matching subscriptions and `getSubscription(SubscriptionId)` returning a single subscription (or `null`). Backed by a new `SubscriptionStore::findByCriteria()` contract for non-locking reads, with an in-memory test implementation and corresponding unit tests.